### PR TITLE
Alban/ebpf 2

### DIFF
--- a/docker/tcpv4tracer.py
+++ b/docker/tcpv4tracer.py
@@ -193,7 +193,6 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 }
 """
 
-TASK_COMM_LEN = 16   # linux/sched.h
 class TCPEvt(ctypes.Structure):
 	_fields_ = [
 		("type", ctypes.c_char * 12),
@@ -206,11 +205,12 @@ class TCPEvt(ctypes.Structure):
 
 def print_event(cpu, data, size):
 	event = ctypes.cast(data, ctypes.POINTER(TCPEvt)).contents
-	print("%-12s %-6s %-16s %-16s %-16s %-6s %-6s" % (event.type.decode('utf-8'), event.pid, " ",
+	print("%s %s %s %s %s %s %s" % (event.type.decode('utf-8'), event.pid,
 	    inet_ntoa(event.saddr),
 	    inet_ntoa(event.daddr),
 	    event.sport,
 	    event.dport,
+	    "unknown",
 	    ))
 
 if args.pid:
@@ -223,8 +223,7 @@ else:
 b = BPF(text=bpf_text)
 
 # header
-print("%-12s %-6s %-16s %-16s %-16s %-6s %-6s" % ("TYPE", "PID", "COMM", "SADDR", "DADDR",
-    "SPORT", "DPORT"))
+print("TYPE PID SADDR DADDR SPORT DPORT NETNS")
 
 def inet_ntoa(addr):
 	dq = ''

--- a/docker/tcpv4tracer.py
+++ b/docker/tcpv4tracer.py
@@ -26,8 +26,13 @@ bpf_text = """
 #include <net/net_namespace.h>
 #include <bcc/proto.h>
 
+#define TCP_EVENT_TYPE_CONNECT 1
+#define TCP_EVENT_TYPE_ACCEPT  2
+#define TCP_EVENT_TYPE_CLOSE   3
+
 struct tcp_event_t {
-	char type[12];
+	u32 type;
+	u32 netns;
 	u32 pid;
 	u32 saddr;
 	u32 daddr;
@@ -75,19 +80,30 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 	struct ns_common *ns;
 	u32 saddr = 0, daddr = 0;
 	u16 sport = 0, dport = 0;
+        u32 net_ns_inum = 0;
 	bpf_probe_read(&sport, sizeof(sport), &((struct inet_sock *)skp)->inet_sport);
 	bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
 	bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
 	bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
 
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+	possible_net_t skc_net = {0,};
+	bpf_probe_read(&skc_net, sizeof(skc_net), &skp->__sk_common.skc_net);
+	bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+	net_ns_inum = 0;
+#endif
+
 	// output
 	struct tcp_event_t evt = {
-		.type = "connect",
+		.type = TCP_EVENT_TYPE_CONNECT,
 		.pid = pid >> 32,
 		.saddr = saddr,
 		.daddr = daddr,
 		.sport = ntohs(sport),
 		.dport = ntohs(dport),
+		.netns = net_ns_inum,
 	};
 
 	u16 family = 0;
@@ -126,19 +142,30 @@ int kretprobe__tcp_close(struct pt_regs *ctx)
 	struct sock *skp = *skpp;
 	u32 saddr = 0, daddr = 0;
 	u16 sport = 0, dport = 0;
+        u32 net_ns_inum = 0;
 	bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
 	bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
 	bpf_probe_read(&sport, sizeof(sport), &((struct inet_sock *)skp)->inet_sport);
 	bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
 
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+	possible_net_t skc_net = {0,};
+	bpf_probe_read(&skc_net, sizeof(skc_net), &skp->__sk_common.skc_net);
+	bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+	net_ns_inum = 0;
+#endif
+
 	// output
 	struct tcp_event_t evt = {
-		.type = "close",
+		.type = TCP_EVENT_TYPE_CLOSE,
 		.pid = pid >> 32,
 		.saddr = saddr,
 		.daddr = daddr,
 		.sport = ntohs(sport),
 		.dport = ntohs(dport),
+		.netns = net_ns_inum,
 	};
 
 	u16 family = 0;
@@ -173,12 +200,27 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 
 	// pull in details
 	u16 family = 0, lport = 0, dport = 0;
+        u32 net_ns_inum = 0;
 	bpf_probe_read(&family, sizeof(family), &newsk->__sk_common.skc_family);
 	bpf_probe_read(&lport, sizeof(lport), &newsk->__sk_common.skc_num);
 	bpf_probe_read(&dport, sizeof(dport), &newsk->__sk_common.skc_dport);
 
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+	possible_net_t skc_net = {0,};
+	bpf_probe_read(&skc_net, sizeof(skc_net), &newsk->__sk_common.skc_net);
+	bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+	net_ns_inum = 0;
+#endif
+
 	if (family == AF_INET) {
-		struct tcp_event_t evt = {.type = "accept", .pid = pid >> 32};
+		struct tcp_event_t evt = {
+                        .type = TCP_EVENT_TYPE_ACCEPT,
+                        .pid = pid >> 32,
+                        .netns = net_ns_inum,
+                };
+
 		bpf_probe_read(&evt.saddr, sizeof(u32),
 			&newsk->__sk_common.skc_rcv_saddr);
 		bpf_probe_read(&evt.daddr, sizeof(u32),
@@ -195,7 +237,8 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 
 class TCPEvt(ctypes.Structure):
 	_fields_ = [
-		("type", ctypes.c_char * 12),
+		("type", ctypes.c_uint),
+		("netns", ctypes.c_uint),
 		("pid", ctypes.c_uint),
 		("saddr", ctypes.c_uint),
 		("daddr", ctypes.c_uint),
@@ -205,12 +248,21 @@ class TCPEvt(ctypes.Structure):
 
 def print_event(cpu, data, size):
 	event = ctypes.cast(data, ctypes.POINTER(TCPEvt)).contents
-	print("%s %s %s %s %s %s %s" % (event.type.decode('utf-8'), event.pid,
+        if event.type == 1:
+            type_str = "connect"
+        elif event.type == 2:
+            type_str = "accept"
+        elif event.type == 3:
+            type_str = "close"
+        else:
+            type_str = "unknown-" + str(event.type)
+
+	print("%s %s %s %s %s %s %s" % (type_str, event.pid,
 	    inet_ntoa(event.saddr),
 	    inet_ntoa(event.daddr),
 	    event.sport,
 	    event.dport,
-	    "unknown",
+	    event.netns,
 	    ))
 
 if args.pid:

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -7,19 +7,9 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
 	log "github.com/Sirupsen/logrus"
-)
-
-type event int
-
-const (
-	// Connect is a TCP CONNECT event
-	Connect event = iota
-	// Accept is a TCP ACCEPT event
-	Accept
-	// Close is a TCP CLOSE event
-	Close
 )
 
 // A ebpfConnection represents a network connection
@@ -31,7 +21,9 @@ type ebpfConnection struct {
 
 // EbpfTracker contains the list of eBPF events, and the eBPF script's command
 type EbpfTracker struct {
-	Cmd *exec.Cmd
+	sync.Mutex
+	cmd  *exec.Cmd
+	dead bool
 
 	activeFlows   map[string]ebpfConnection
 	bufferedFlows []ebpfConnection
@@ -45,44 +37,82 @@ func NewEbpfTracker(bccProgramPath string) *EbpfTracker {
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		log.Errorf("bcc error: %v", err)
+		log.Errorf("EbpfTracker error: %v", err)
 		return nil
 	}
-	go logPipe("bcc stderr:", stderr)
+	go logPipe("EbpfTracker stderr:", stderr)
 
 	tracker := &EbpfTracker{
-		Cmd: cmd,
+		cmd:         cmd,
+		activeFlows: map[string]ebpfConnection{},
 	}
 	go tracker.run()
 	return tracker
 }
 
+func (t *EbpfTracker) handleFlow(eventStr string, tuple fourTuple, pid int) {
+	t.Lock()
+	defer t.Unlock()
+
+	switch eventStr {
+	case "connect":
+		log.Infof("EbpfTracker: connect: %s pid=%v", tuple.String(), pid)
+		conn := ebpfConnection{
+			outgoing: true,
+			tuple:    tuple,
+			pid:      pid,
+		}
+		t.activeFlows[tuple.String()] = conn
+	case "accept":
+		log.Infof("EbpfTracker: accept: %s pid=%v", tuple.String(), pid)
+		conn := ebpfConnection{
+			outgoing: true,
+			tuple:    tuple,
+			pid:      pid,
+		}
+		t.activeFlows[tuple.String()] = conn
+	case "close":
+		log.Infof("EbpfTracker: close: %s pid=%v", tuple.String(), pid)
+		if deadConn, ok := t.activeFlows[tuple.String()]; ok {
+			delete(t.activeFlows, tuple.String())
+			t.bufferedFlows = append(t.bufferedFlows, deadConn)
+		} else {
+			log.Errorf("EbpfTracker error: unmatched close event")
+		}
+	}
+
+}
+
 func (t *EbpfTracker) run() {
-	stdout, err := t.Cmd.StdoutPipe()
+	stdout, err := t.cmd.StdoutPipe()
 	if err != nil {
-		log.Errorf("conntrack error: %v", err)
+		log.Errorf("EbpfTracker error: %v", err)
 		return
 	}
 
-	if err := t.Cmd.Start(); err != nil {
-		log.Errorf("bcc error: %v", err)
+	if err := t.cmd.Start(); err != nil {
+		log.Errorf("EbpfTracker error: %v", err)
 		return
 	}
 
 	defer func() {
-		if err := t.Cmd.Wait(); err != nil {
-			log.Errorf("bcc error: %v", err)
+		if err := t.cmd.Wait(); err != nil {
+			log.Errorf("EbpfTracker error: %v", err)
 		}
+
+		t.Lock()
+		t.dead = true
+		t.Unlock()
 	}()
 
 	reader := bufio.NewReader(stdout)
 	// skip fist line
 	if _, err := reader.ReadString('\n'); err != nil {
-		log.Errorf("bcc error: %v", err)
+		log.Errorf("EbpfTracker error: %v", err)
 		return
 	}
 
-	defer log.Infof("bcc exiting")
+	defer log.Infof("EbpfTracker exiting")
 
 	scn := bufio.NewScanner(reader)
 	for scn.Scan() {
@@ -125,33 +155,18 @@ func (t *EbpfTracker) run() {
 
 		tuple := fourTuple{sourceAddr.String(), destAddr.String(), sourcePort, destPort}
 
-		switch eventStr {
-		case "connect":
-			conn := ebpfConnection{
-				outgoing: true,
-				tuple:    tuple,
-				pid:      pid,
-			}
-			t.activeFlows[tuple.String()] = conn
-		case "accept":
-			conn := ebpfConnection{
-				outgoing: true,
-				tuple:    tuple,
-				pid:      pid,
-			}
-			t.activeFlows[tuple.String()] = conn
-		case "close":
-			if deadConn, ok := t.activeFlows[tuple.String()]; ok {
-				delete(t.activeFlows, tuple.String())
-				t.bufferedFlows = append(t.bufferedFlows, deadConn)
-			}
-		}
-
+		t.handleFlow(eventStr, tuple, pid)
 	}
 }
 
-// WalkConnections - walk through the connectionEvents
-func (t EbpfTracker) WalkConnections(f func(ebpfConnection)) {
+// walkFlows calls f with all active flows and flows that have come and gone
+// since the last call to walkFlows
+func (t *EbpfTracker) walkFlows(f func(ebpfConnection)) {
+	t.Lock()
+	defer t.Unlock()
+
+	log.Infof("EbpfTracker: WalkConnections activeFlows: %d bufferedFlows: %d", len(t.activeFlows), len(t.bufferedFlows))
+
 	for _, flow := range t.activeFlows {
 		f(flow)
 	}
@@ -159,4 +174,11 @@ func (t EbpfTracker) WalkConnections(f func(ebpfConnection)) {
 		f(flow)
 	}
 	t.bufferedFlows = t.bufferedFlows[:0]
+}
+
+func (t *EbpfTracker) hasDied() bool {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.dead
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -89,6 +89,10 @@ type fourTuple struct {
 	fromPort, toPort uint16
 }
 
+func (t fourTuple) String() string {
+	return fmt.Sprintf("%s:%d-%s:%d", t.fromAddr, t.fromPort, t.toAddr, t.toPort)
+}
+
 // key is a sortable direction-independent key for tuples, used to look up a
 // fourTuple, when you are unsure of it's direction.
 func (t fourTuple) key() string {
@@ -154,35 +158,19 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	// eBPF
 	if r.ebpfEnabled {
-		fromNodeInfo := map[string]string{
-			// FIXME: remove this
-			Procspied: "true",
-			EBPF:      "true",
-		}
-		toNodeInfo := map[string]string{
-			Procspied: "true",
-			EBPF:      "true",
-		}
-		r.ebpfTracker.WalkEvents(func(e ConnectionEvent) {
-			tuple := fourTuple{
-				e.SourceAddress.String(),
-				e.DestAddress.String(),
-				e.SourcePort,
-				e.DestPort,
+		r.ebpfTracker.WalkConnections(func(e ebpfConnection) {
+			fromNodeInfo := map[string]string{
+				Procspied:         "true",
+				EBPF:              "true",
+				process.PID:       strconv.Itoa(e.pid),
+				report.HostNodeID: hostNodeID,
+			}
+			toNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
 			}
 
-			fromNodeInfo[process.PID] = strconv.Itoa(e.Pid)
-			fromNodeInfo[report.HostNodeID] = hostNodeID
-			switch e.Type {
-			case Connect:
-				r.addConnection(&rpt, tuple, "", fromNodeInfo, toNodeInfo)
-			// TODO the node that ACCEPTs is at the receving end of hte connection
-			// so maybe we should not add a new node?
-			case Accept:
-				r.addConnection(&rpt, tuple, "", fromNodeInfo, toNodeInfo)
-			case Close:
-				r.removeConnection(&rpt, tuple, "", fromNodeInfo, toNodeInfo)
-			}
+			r.addConnection(&rpt, e.tuple, "", fromNodeInfo, toNodeInfo)
 		})
 	}
 
@@ -237,17 +225,6 @@ func (r *Reporter) addConnection(rpt *report.Report, t fourTuple, namespaceID st
 	)
 	rpt.Endpoint = rpt.Endpoint.AddNode(fromNode.WithEdge(toNode.ID, report.EdgeMetadata{}))
 	rpt.Endpoint = rpt.Endpoint.AddNode(toNode)
-}
-
-func (r *Reporter) removeConnection(rpt *report.Report, t fourTuple, namespaceID string, extraFromNode, extraToNode map[string]string) {
-	// create node from tuple
-	var (
-		fromNode = r.makeEndpointNode(namespaceID, t.fromAddr, t.fromPort, extraFromNode)
-		toNode   = r.makeEndpointNode(namespaceID, t.toAddr, t.toPort, extraToNode)
-	)
-	// check
-	rpt.Endpoint.RemoveNode(fromNode)
-	rpt.Endpoint.RemoveNode(toNode)
 }
 
 func (r *Reporter) makeEndpointNode(namespaceID string, addr string, port uint16, extra map[string]string) report.Node {

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -210,7 +210,7 @@ func (r *Reporter) Report() (report.Report, error) {
 			}
 
 			r.addConnection(&rpt, e.tuple, e.netns, fromNodeInfo, toNodeInfo)
-			log.Infof("reporter: adding %s", e.tuple.String())
+			log.Infof("reporter: adding %s netns=%s", e.tuple.String(), e.netns)
 		})
 		log.Infof("reporter: generating eBPF report done")
 	}

--- a/report/topology.go
+++ b/report/topology.go
@@ -119,14 +119,6 @@ func (t Topology) AddNode(node Node) Topology {
 	return t
 }
 
-// RemoveNode removes a node from the Topology.
-// The Topology is returned to enable chaining.
-func (t Topology) RemoveNode(node Node) Topology {
-	delete(t.Nodes, node.ID)
-
-	return t
-}
-
 // GetShape returns the current topology shape, or the default if there isn't one.
 func (t Topology) GetShape() string {
 	if t.Shape == "" {


### PR DESCRIPTION
Maintain state of eBPF-tracked connections in `ebpf.go`, so that `renderer.go` is more decoupled - and can simply iterate over connections. 
