### PR TITLE
Add eBPF connection tracking

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,12 @@
-FROM alpine:3.3
+FROM zlim/bcc
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >>/etc/apk/repositories && \
-	apk add --update bash runit conntrack-tools iproute2 util-linux curl && \
-	rm -rf /var/cache/apk/*
+RUN apt-get update -y && apt-get install -y bash runit conntrack iproute2 util-linux curl python bcc-tools python-bcc libbcc
 ADD ./docker.tgz /
 ADD ./demo.json /
 ADD ./weave /usr/bin/
-COPY ./scope ./runsvinit ./entrypoint.sh /home/weave/
+COPY ./scope ./runsvinit ./entrypoint.sh ./tcpv4tracer.py /home/weave/
 COPY ./run-app /etc/service/app/run
 COPY ./run-probe /etc/service/probe/run
 EXPOSE 4040

--- a/docker/tcpv4tracer.py
+++ b/docker/tcpv4tracer.py
@@ -1,0 +1,291 @@
+#!/usr/bin/python
+#
+# tcpv4tracer   Trace TCP IPv4 connections.
+#               For Linux, uses BCC, eBPF. Embedded C.
+#
+# USAGE: tcpv4tracer [-h] [-p PID]
+#
+from __future__ import print_function
+from bcc import BPF
+
+import argparse
+import ctypes
+
+parser = argparse.ArgumentParser(
+    description="Trace TCP IPv4 connections",
+    formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument("-p", "--pid",
+    help="trace this PID only")
+args = parser.parse_args()
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <net/inet_sock.h>
+#include <net/net_namespace.h>
+#include <bcc/proto.h>
+
+#define TCP_EVENT_TYPE_CONNECT 1
+#define TCP_EVENT_TYPE_ACCEPT  2
+#define TCP_EVENT_TYPE_CLOSE   3
+
+struct tcp_event_t {
+        u32 type;
+        u32 netns;
+        u32 pid;
+        u32 saddr;
+        u32 daddr;
+        u16 sport;
+        u16 dport;
+};
+
+BPF_PERF_OUTPUT(tcp_event);
+BPF_HASH(connectsock, u64, struct sock *);
+BPF_HASH(closesock, u64, struct sock *);
+
+int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
+{
+        u64 pid = bpf_get_current_pid_tgid();
+
+        ##FILTER_PID##
+
+        // stash the sock ptr for lookup on return
+        connectsock.update(&pid, &sk);
+
+        return 0;
+};
+
+int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
+{
+        int ret = PT_REGS_RC(ctx);
+        u64 pid = bpf_get_current_pid_tgid();
+
+        struct sock **skpp;
+        skpp = connectsock.lookup(&pid);
+        if (skpp == 0) {
+                return 0;       // missed entry
+        }
+
+        if (ret != 0) {
+                // failed to send SYNC packet, may not have populated
+                // socket __sk_common.{skc_rcv_saddr, ...}
+                connectsock.delete(&pid);
+                return 0;
+        }
+
+
+        // pull in details
+        struct sock *skp = *skpp;
+        struct ns_common *ns;
+        u32 saddr = 0, daddr = 0;
+        u16 sport = 0, dport = 0;
+        u32 net_ns_inum = 0;
+        bpf_probe_read(&sport, sizeof(sport), &((struct inet_sock *)skp)->inet_sport);
+        bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
+        bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+        bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+        possible_net_t skc_net = {0,};
+        bpf_probe_read(&skc_net, sizeof(skc_net), &skp->__sk_common.skc_net);
+        bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+        net_ns_inum = 0;
+#endif
+
+        // output
+        struct tcp_event_t evt = {
+                .type = TCP_EVENT_TYPE_CONNECT,
+                .pid = pid >> 32,
+                .saddr = saddr,
+                .daddr = daddr,
+                .sport = ntohs(sport),
+                .dport = ntohs(dport),
+                .netns = net_ns_inum,
+        };
+
+        u16 family = 0;
+        bpf_probe_read(&family, sizeof(family), &skp->__sk_common.skc_family);
+
+        tcp_event.perf_submit(ctx, &evt, sizeof(evt));
+
+        connectsock.delete(&pid);
+
+        return 0;
+}
+
+int kprobe__tcp_close(struct pt_regs *ctx, struct sock *sk)
+{
+        u64 pid = bpf_get_current_pid_tgid();
+
+        ##FILTER_PID##
+
+        // stash the sock ptr for lookup on return
+        closesock.update(&pid, &sk);
+
+        return 0;
+};
+
+int kretprobe__tcp_close(struct pt_regs *ctx)
+{
+        u64 pid = bpf_get_current_pid_tgid();
+
+        struct sock **skpp;
+        skpp = closesock.lookup(&pid);
+        if (skpp == 0) {
+                return 0;       // missed entry
+        }
+
+        // pull in details
+        struct sock *skp = *skpp;
+        u32 saddr = 0, daddr = 0;
+        u16 sport = 0, dport = 0;
+        u32 net_ns_inum = 0;
+        bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
+        bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+        bpf_probe_read(&sport, sizeof(sport), &((struct inet_sock *)skp)->inet_sport);
+        bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+        possible_net_t skc_net = {0,};
+        bpf_probe_read(&skc_net, sizeof(skc_net), &skp->__sk_common.skc_net);
+        bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+        net_ns_inum = 0;
+#endif
+
+        // output
+        struct tcp_event_t evt = {
+                .type = TCP_EVENT_TYPE_CLOSE,
+                .pid = pid >> 32,
+                .saddr = saddr,
+                .daddr = daddr,
+                .sport = ntohs(sport),
+                .dport = ntohs(dport),
+                .netns = net_ns_inum,
+        };
+
+        u16 family = 0;
+        bpf_probe_read(&family, sizeof(family), &skp->__sk_common.skc_family);
+
+        // do not send event if IP address is 0.0.0.0 or port is 0
+        if (evt.saddr != 0 && evt.daddr != 0 && evt.sport != 0 && evt.dport != 0) {
+            tcp_event.perf_submit(ctx, &evt, sizeof(evt));
+        }
+
+        closesock.delete(&pid);
+
+        return 0;
+}
+
+int kretprobe__inet_csk_accept(struct pt_regs *ctx)
+{
+        struct sock *newsk = (struct sock *)PT_REGS_RC(ctx);
+        u64 pid = bpf_get_current_pid_tgid();
+
+        ##FILTER_PID##
+
+        if (newsk == NULL)
+                return 0;
+
+        // check this is TCP
+        u8 protocol = 0;
+        // workaround for reading the sk_protocol bitfield:
+        bpf_probe_read(&protocol, 1, (void *)((long)&newsk->sk_wmem_queued) - 3);
+        if (protocol != IPPROTO_TCP)
+                return 0;
+
+        // pull in details
+        u16 family = 0, lport = 0, dport = 0;
+        u32 net_ns_inum = 0;
+        bpf_probe_read(&family, sizeof(family), &newsk->__sk_common.skc_family);
+        bpf_probe_read(&lport, sizeof(lport), &newsk->__sk_common.skc_num);
+        bpf_probe_read(&dport, sizeof(dport), &newsk->__sk_common.skc_dport);
+
+// Get network namespace id, if kernel supports it
+#ifdef CONFIG_NET_NS
+        possible_net_t skc_net = {0,};
+        bpf_probe_read(&skc_net, sizeof(skc_net), &newsk->__sk_common.skc_net);
+        bpf_probe_read(&net_ns_inum, sizeof(net_ns_inum), &skc_net.net->ns.inum);
+#else
+        net_ns_inum = 0;
+#endif
+
+        if (family == AF_INET) {
+                struct tcp_event_t evt = {
+                        .type = TCP_EVENT_TYPE_ACCEPT,
+                        .pid = pid >> 32,
+                        .netns = net_ns_inum,
+                };
+
+                bpf_probe_read(&evt.saddr, sizeof(u32),
+                        &newsk->__sk_common.skc_rcv_saddr);
+                bpf_probe_read(&evt.daddr, sizeof(u32),
+                        &newsk->__sk_common.skc_daddr);
+                        evt.sport = lport;
+                evt.dport = ntohs(dport);
+                tcp_event.perf_submit(ctx, &evt, sizeof(evt));
+        }
+        // else drop
+
+        return 0;
+}
+"""
+
+class TCPEvt(ctypes.Structure):
+        _fields_ = [
+                ("type", ctypes.c_uint),
+                ("netns", ctypes.c_uint),
+                ("pid", ctypes.c_uint),
+                ("saddr", ctypes.c_uint),
+                ("daddr", ctypes.c_uint),
+                ("sport", ctypes.c_ushort),
+                ("dport", ctypes.c_ushort),
+        ]
+
+def print_event(cpu, data, size):
+        event = ctypes.cast(data, ctypes.POINTER(TCPEvt)).contents
+        if event.type == 1:
+            type_str = "connect"
+        elif event.type == 2:
+            type_str = "accept"
+        elif event.type == 3:
+            type_str = "close"
+        else:
+            type_str = "unknown-" + str(event.type)
+
+        print("%s %s %s %s %s %s %s" % (type_str, event.pid,
+            inet_ntoa(event.saddr),
+            inet_ntoa(event.daddr),
+            event.sport,
+            event.dport,
+            event.netns,
+            ))
+
+if args.pid:
+    bpf_text = bpf_text.replace('##FILTER_PID##',
+        'if (pid != %s) { return 0; }' % args.pid)
+else:
+    bpf_text = bpf_text.replace('##FILTER_PID##', '')
+
+# initialize BPF
+b = BPF(text=bpf_text)
+
+# header
+print("TYPE PID SADDR DADDR SPORT DPORT NETNS")
+
+def inet_ntoa(addr):
+        dq = ''
+        for i in range(0, 4):
+                dq = dq + str(addr & 0xff)
+                if (i != 3):
+                        dq = dq + '.'
+                addr = addr >> 8
+        return dq
+
+b["tcp_event"].open_perf_buffer(print_event)
+while True:
+        b.kprobe_poll()

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -1,0 +1,226 @@
+package endpoint
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// TCPV4TracerLocation is the location of the Python script
+// that delivers the eBPF messages coming from the kernel.
+var TCPV4TracerLocation = "/home/weave/tcpv4tracer.py"
+
+// A ebpfConnection represents a network connection
+type ebpfConnection struct {
+	tuple            fourTuple
+	networkNamespace string
+	incoming         bool
+	pid              int
+}
+
+type eventTracker interface {
+	handleFlow(eventType string, tuple fourTuple, pid int, networkNamespace string)
+	hasDied() bool
+	run()
+	walkFlows(f func(ebpfConnection))
+	initialize()
+	isInitialized() bool
+}
+
+// nilTracker is a tracker that does nothing, and it implements the eventTracker interface.
+// It is returned when the ebpfEnabled flag is false.
+type nilTracker struct{}
+
+func (n nilTracker) handleFlow(_ string, _ fourTuple, _ int, _ string) {}
+func (n nilTracker) hasDied() bool                                     { return true }
+func (n nilTracker) run()                                              {}
+func (n nilTracker) walkFlows(f func(ebpfConnection))                  {}
+func (n nilTracker) initialize()                                       {}
+func (n nilTracker) isInitialized() bool                               { return false }
+
+// EbpfTracker contains the list of eBPF events, and the eBPF script's command
+type EbpfTracker struct {
+	sync.Mutex
+	cmd *exec.Cmd
+
+	initialized bool
+	dead        bool
+
+	activeFlows   map[string]ebpfConnection
+	bufferedFlows []ebpfConnection
+}
+
+func newEbpfTracker(ebpfEnabled bool) eventTracker {
+	if !ebpfEnabled {
+		return &nilTracker{}
+	}
+	cmd := exec.Command(TCPV4TracerLocation)
+	env := os.Environ()
+	cmd.Env = append(env, "PYTHONUNBUFFERED=1")
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		log.Errorf("EbpfTracker error: %v", err)
+		return nil
+	}
+	go logPipe("EbpfTracker stderr:", stderr)
+
+	tracker := &EbpfTracker{
+		cmd:         cmd,
+		activeFlows: map[string]ebpfConnection{},
+	}
+	log.Info("EbpfTracker started")
+	go tracker.run()
+	return tracker
+}
+
+func (t *EbpfTracker) handleFlow(eventType string, tuple fourTuple, pid int, networkNamespace string) {
+	t.Lock()
+	defer t.Unlock()
+
+	switch eventType {
+	case "connect":
+		conn := ebpfConnection{
+			incoming:         false,
+			tuple:            tuple,
+			pid:              pid,
+			networkNamespace: networkNamespace,
+		}
+		t.activeFlows[tuple.String()] = conn
+	case "accept":
+		conn := ebpfConnection{
+			incoming:         true,
+			tuple:            tuple,
+			pid:              pid,
+			networkNamespace: networkNamespace,
+		}
+		t.activeFlows[tuple.String()] = conn
+	case "close":
+		if deadConn, ok := t.activeFlows[tuple.String()]; ok {
+			delete(t.activeFlows, tuple.String())
+			t.bufferedFlows = append(t.bufferedFlows, deadConn)
+		} else {
+			log.Errorf("EbpfTracker error: unmatched close event: %s pid=%d netns=%s", tuple.String(), pid, networkNamespace)
+		}
+	}
+
+}
+
+func (t *EbpfTracker) run() {
+	stdout, err := t.cmd.StdoutPipe()
+	if err != nil {
+		log.Errorf("EbpfTracker error: %v", err)
+		return
+	}
+
+	if err := t.cmd.Start(); err != nil {
+		log.Errorf("EbpfTracker error: %v", err)
+		return
+	}
+
+	defer func() {
+		if err := t.cmd.Wait(); err != nil {
+			log.Errorf("EbpfTracker error: %v", err)
+		}
+
+		t.Lock()
+		t.dead = true
+		t.Unlock()
+	}()
+
+	reader := bufio.NewReader(stdout)
+	// skip fist line
+	if _, err := reader.ReadString('\n'); err != nil {
+		log.Errorf("EbpfTracker error: %v", err)
+		return
+	}
+
+	defer log.Infof("EbpfTracker exiting")
+
+	scn := bufio.NewScanner(reader)
+	for scn.Scan() {
+		txt := scn.Text()
+		line := strings.Fields(txt)
+
+		if len(line) != 7 {
+			log.Errorf("error parsing line %q", txt)
+			continue
+		}
+
+		eventType := line[0]
+
+		pid, err := strconv.Atoi(line[1])
+		if err != nil {
+			log.Errorf("error parsing pid %q: %v", line[1], err)
+			continue
+		}
+
+		sourceAddr := net.ParseIP(line[2])
+		if sourceAddr == nil {
+			log.Errorf("error parsing sourceAddr %q: %v", line[2], err)
+			continue
+		}
+
+		destAddr := net.ParseIP(line[3])
+		if destAddr == nil {
+			log.Errorf("error parsing destAddr %q: %v", line[3], err)
+			continue
+		}
+
+		sPort, err := strconv.ParseUint(line[4], 10, 16)
+		if err != nil {
+			log.Errorf("error parsing sourcePort %q: %v", line[4], err)
+			continue
+		}
+		sourcePort := uint16(sPort)
+
+		dPort, err := strconv.ParseUint(line[5], 10, 16)
+		if err != nil {
+			log.Errorf("error parsing destPort %q: %v", line[5], err)
+			continue
+		}
+		destPort := uint16(dPort)
+
+		networkNamespace := line[6]
+
+		tuple := fourTuple{sourceAddr.String(), destAddr.String(), sourcePort, destPort}
+
+		t.handleFlow(eventType, tuple, pid, networkNamespace)
+	}
+}
+
+// walkFlows calls f with all active flows and flows that have come and gone
+// since the last call to walkFlows
+func (t *EbpfTracker) walkFlows(f func(ebpfConnection)) {
+	t.Lock()
+	defer t.Unlock()
+
+	for _, flow := range t.activeFlows {
+		f(flow)
+	}
+	for _, flow := range t.bufferedFlows {
+		f(flow)
+	}
+	t.bufferedFlows = t.bufferedFlows[:0]
+}
+
+func (t *EbpfTracker) hasDied() bool {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.dead
+}
+
+func (t *EbpfTracker) initialize() {
+	t.initialized = true
+}
+
+func (t *EbpfTracker) isInitialized() bool {
+	return t.initialized
+}

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -35,7 +35,7 @@ type eventTracker interface {
 }
 
 // nilTracker is a tracker that does nothing, and it implements the eventTracker interface.
-// It is returned when the ebpfEnabled flag is false.
+// It is returned when the useEbpfConn flag is false.
 type nilTracker struct{}
 
 func (n nilTracker) handleConnection(_ string, _ fourTuple, _ int, _ string) {}
@@ -59,8 +59,8 @@ type EbpfTracker struct {
 	closedConnections []ebpfConnection
 }
 
-func newEbpfTracker(ebpfEnabled bool) eventTracker {
-	if !ebpfEnabled {
+func newEbpfTracker(useEbpfConn bool) eventTracker {
+	if !useEbpfConn {
 		return &nilTracker{}
 	}
 	cmd := exec.Command(TCPV4TracerLocation)

--- a/probe/endpoint/ebpf.go
+++ b/probe/endpoint/ebpf.go
@@ -55,9 +55,7 @@ type EbpfTracker struct {
 	initialized bool
 	dead        bool
 
-	// active connections
-	openConnections map[string]ebpfConnection
-	// closed connections
+	openConnections   map[string]ebpfConnection
 	closedConnections []ebpfConnection
 }
 

--- a/probe/endpoint/ebpf/main.go
+++ b/probe/endpoint/ebpf/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/weaveworks/scope/probe/endpoint"
+)
+
+func main() {
+	tr := endpoint.NewEbpfTracker("/home/asymmetric/code/kinvolk/bcc/examples/tracing/tcpv4tracer.py")
+
+	if tr == nil {
+		fmt.Fprintf(os.Stderr, "error creating tracker\n")
+		os.Exit(1)
+	}
+
+	// create some http connection within these 10 seconds
+	time.Sleep(10 * time.Second)
+
+	tr.WalkEvents(func(e endpoint.ConnectionEvent) {
+		fmt.Println(e)
+	})
+
+	fmt.Println("done")
+}

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -1,0 +1,43 @@
+package endpoint
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// fourTuple is an (IP, port, IP, port) tuple, representing a connection
+type fourTuple struct {
+	fromAddr, toAddr string
+	fromPort, toPort uint16
+}
+
+func (t fourTuple) String() string {
+	return fmt.Sprintf("%s:%d-%s:%d", t.fromAddr, t.fromPort, t.toAddr, t.toPort)
+}
+
+// key is a sortable direction-independent key for tuples, used to look up a
+// fourTuple, when you are unsure of it's direction.
+func (t fourTuple) key() string {
+	key := []string{
+		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),
+		fmt.Sprintf("%s:%d", t.toAddr, t.toPort),
+	}
+	sort.Strings(key)
+	return strings.Join(key, " ")
+}
+
+// reverse flips the direction of the tuple
+func (t *fourTuple) reverse() {
+	t.fromAddr, t.fromPort, t.toAddr, t.toPort = t.toAddr, t.toPort, t.fromAddr, t.fromPort
+}
+
+// reverse flips the direction of a tuple, without side effects
+func reverse(tuple fourTuple) fourTuple {
+	return fourTuple{
+		fromAddr: tuple.toAddr,
+		toAddr:   tuple.fromAddr,
+		fromPort: tuple.toPort,
+		toPort:   tuple.fromPort,
+	}
+}

--- a/probe/endpoint/four_tuple.go
+++ b/probe/endpoint/four_tuple.go
@@ -17,7 +17,7 @@ func (t fourTuple) String() string {
 }
 
 // key is a sortable direction-independent key for tuples, used to look up a
-// fourTuple, when you are unsure of it's direction.
+// fourTuple when you are unsure of its direction.
 func (t fourTuple) key() string {
 	key := []string{
 		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),

--- a/probe/endpoint/procspy/background_reader_linux.go
+++ b/probe/endpoint/procspy/background_reader_linux.go
@@ -38,6 +38,28 @@ func newBackgroundReader(walker process.Walker) *backgroundReader {
 	return br
 }
 
+func newForegroundReader(walker process.Walker) *backgroundReader {
+	br := &backgroundReader{
+		stopc:         make(chan struct{}),
+		latestSockets: map[uint64]*Proc{},
+	}
+	var (
+		walkc   = make(chan walkResult)
+		ticker  = time.NewTicker(time.Millisecond) // fire every millisecond
+		pWalker = newPidWalker(walker, ticker.C, fdBlockSize)
+	)
+
+	go performWalk(pWalker, walkc)
+
+	result := <-walkc
+	br.mtx.Lock()
+	br.latestBuf = result.buf
+	br.latestSockets = result.sockets
+	br.mtx.Unlock()
+
+	return br
+}
+
 func (br *backgroundReader) stop() {
 	close(br.stopc)
 }
@@ -60,6 +82,7 @@ func performWalk(w pidWalker, c chan<- walkResult) {
 	var (
 		err    error
 		result = walkResult{
+			// TODO should we increase buf size?
 			buf: bytes.NewBuffer(make([]byte, 0, 5000)),
 		}
 	)

--- a/probe/endpoint/procspy/spy_darwin.go
+++ b/probe/endpoint/procspy/spy_darwin.go
@@ -18,6 +18,11 @@ func NewConnectionScanner(_ process.Walker) ConnectionScanner {
 	return &darwinScanner{}
 }
 
+// NewSyncConnectionScanner creates a new syncrhonous Darwin ConnectionScanner
+func NewSyncConnectionScanner(_ process.Walker) ConnectionScanner {
+	return &darwinScanner{}
+}
+
 type darwinScanner struct{}
 
 // Connections returns all established (TCP) connections. No need to be root

--- a/probe/endpoint/procspy/spy_linux.go
+++ b/probe/endpoint/procspy/spy_linux.go
@@ -38,6 +38,12 @@ func NewConnectionScanner(walker process.Walker) ConnectionScanner {
 	return &linuxScanner{br}
 }
 
+// NewSyncConnectionScanner creates a new synchronous Linux ConnectionScanner
+func NewSyncConnectionScanner(walker process.Walker) ConnectionScanner {
+	br := newForegroundReader(walker)
+	return &linuxScanner{br}
+}
+
 type linuxScanner struct {
 	br *backgroundReader
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -1,10 +1,7 @@
 package endpoint
 
 import (
-	"fmt"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +16,7 @@ const (
 	Addr            = "addr" // typically IPv4
 	Port            = "port"
 	Conntracked     = "conntracked"
+	EBPF            = "eBPF"
 	Procspied       = "procspied"
 	ReverseDNSNames = "reverse_dns_names"
 	SnoopedDNSNames = "snooped_dns_names"
@@ -31,6 +29,7 @@ type ReporterConfig struct {
 	SpyProcs     bool
 	UseConntrack bool
 	WalkProc     bool
+	EbpfEnabled  bool
 	ProcRoot     string
 	BufferSize   int
 	Scanner      procspy.ConnectionScanner
@@ -41,6 +40,7 @@ type ReporterConfig struct {
 type Reporter struct {
 	conf            ReporterConfig
 	flowWalker      flowWalker // interface
+	ebpfTracker     eventTracker
 	natMapper       natMapper
 	reverseResolver *reverseResolver
 }
@@ -66,6 +66,7 @@ func NewReporter(conf ReporterConfig) *Reporter {
 	return &Reporter{
 		conf:            conf,
 		flowWalker:      newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize),
+		ebpfTracker:     newEbpfTracker(conf.EbpfEnabled),
 		natMapper:       makeNATMapper(newConntrackFlowWalker(conf.UseConntrack, conf.ProcRoot, conf.BufferSize, "--any-nat")),
 		reverseResolver: newReverseResolver(),
 	}
@@ -82,27 +83,6 @@ func (r *Reporter) Stop() {
 	r.conf.Scanner.Stop()
 }
 
-type fourTuple struct {
-	fromAddr, toAddr string
-	fromPort, toPort uint16
-}
-
-// key is a sortable direction-independent key for tuples, used to look up a
-// fourTuple, when you are unsure of it's direction.
-func (t fourTuple) key() string {
-	key := []string{
-		fmt.Sprintf("%s:%d", t.fromAddr, t.fromPort),
-		fmt.Sprintf("%s:%d", t.toAddr, t.toPort),
-	}
-	sort.Strings(key)
-	return strings.Join(key, " ")
-}
-
-// reverse flips the direction of the tuple
-func (t *fourTuple) reverse() {
-	t.fromAddr, t.fromPort, t.toAddr, t.toPort = t.toAddr, t.toPort, t.fromAddr, t.fromPort
-}
-
 // Report implements Reporter.
 func (r *Reporter) Report() (report.Report, error) {
 	defer func(begin time.Time) {
@@ -111,6 +91,7 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	hostNodeID := report.MakeHostNodeID(r.conf.HostID)
 	rpt := report.MakeReport()
+
 	seenTuples := map[string]fourTuple{}
 
 	// Consult the flowWalker for short-lived connections
@@ -144,6 +125,7 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	if r.conf.WalkProc {
 		conns, err := r.conf.Scanner.Connections(r.conf.SpyProcs)
+		defer r.procParsingSwitcher()
 		if err != nil {
 			return rpt, err
 		}
@@ -174,11 +156,39 @@ func (r *Reporter) Report() (report.Report, error) {
 			// the direction.
 			canonical, ok := seenTuples[tuple.key()]
 			if (ok && canonical != tuple) || (!ok && tuple.fromPort < tuple.toPort) {
-				tuple.reverse()
-				toNodeInfo, fromNodeInfo = fromNodeInfo, toNodeInfo
+				r.feedToEbpf(tuple, true, int(conn.Proc.PID), namespaceID)
+				r.addConnection(&rpt, reverse(tuple), namespaceID, toNodeInfo, fromNodeInfo)
+			} else {
+				r.feedToEbpf(tuple, false, int(conn.Proc.PID), namespaceID)
+				r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
 			}
-			r.addConnection(&rpt, tuple, namespaceID, fromNodeInfo, toNodeInfo)
+
 		}
+	}
+
+	// eBPF
+	if r.conf.EbpfEnabled && !r.ebpfTracker.hasDied() {
+		r.ebpfTracker.walkFlows(func(e ebpfConnection) {
+			fromNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
+			}
+			toNodeInfo := map[string]string{
+				Procspied: "true",
+				EBPF:      "true",
+			}
+			if e.pid > 0 {
+				fromNodeInfo[process.PID] = strconv.Itoa(e.pid)
+				fromNodeInfo[report.HostNodeID] = hostNodeID
+			}
+
+			if e.incoming {
+				r.addConnection(&rpt, reverse(e.tuple), e.networkNamespace, toNodeInfo, fromNodeInfo)
+			} else {
+				r.addConnection(&rpt, e.tuple, e.networkNamespace, fromNodeInfo, toNodeInfo)
+			}
+
+		})
 	}
 
 	r.natMapper.applyNAT(rpt, r.conf.HostID)
@@ -213,4 +223,28 @@ func (r *Reporter) makeEndpointNode(namespaceID string, addr string, port uint16
 
 func newu64(i uint64) *uint64 {
 	return &i
+}
+
+// procParsingSwitcher make sure that if eBPF tracking is enabled,
+// connections coming from /proc parsing are only walked once.
+func (r *Reporter) procParsingSwitcher() {
+	if r.conf.WalkProc && r.conf.EbpfEnabled {
+		r.conf.WalkProc = false
+		r.ebpfTracker.initialize()
+	}
+}
+
+// if the eBPF tracker is enabled, feed the existing connections into it
+// incoming connections correspond to "accept" events
+// outgoing connections correspond to "connect" events
+func (r Reporter) feedToEbpf(tuple fourTuple, incoming bool, pid int, namespaceID string) {
+	if r.conf.EbpfEnabled && !r.ebpfTracker.isInitialized() {
+		tcpEventType := "connect"
+
+		if incoming {
+			tcpEventType = "accept"
+		}
+
+		r.ebpfTracker.handleFlow(tcpEventType, tuple, pid, namespaceID)
+	}
 }

--- a/probe/endpoint/reporter.go
+++ b/probe/endpoint/reporter.go
@@ -81,6 +81,7 @@ func (r *Reporter) Stop() {
 	r.natMapper.stop()
 	r.reverseResolver.stop()
 	r.conf.Scanner.Stop()
+	// TODO add a Stop method for ebpfTracker
 }
 
 // Report implements Reporter.
@@ -168,7 +169,7 @@ func (r *Reporter) Report() (report.Report, error) {
 
 	// eBPF
 	if r.conf.EbpfEnabled && !r.ebpfTracker.hasDied() {
-		r.ebpfTracker.walkFlows(func(e ebpfConnection) {
+		r.ebpfTracker.walkConnections(func(e ebpfConnection) {
 			fromNodeInfo := map[string]string{
 				Procspied: "true",
 				EBPF:      "true",
@@ -245,6 +246,6 @@ func (r Reporter) feedToEbpf(tuple fourTuple, incoming bool, pid int, namespaceI
 			tcpEventType = "accept"
 		}
 
-		r.ebpfTracker.handleFlow(tcpEventType, tuple, pid, namespaceID)
+		r.ebpfTracker.handleConnection(tcpEventType, tuple, pid, namespaceID)
 	}
 }

--- a/prog/main.go
+++ b/prog/main.go
@@ -91,7 +91,7 @@ type probeFlags struct {
 
 	spyProcs    bool // Associate endpoints with processes (must be root)
 	procEnabled bool // Produce process topology & process nodes in endpoint
-	ebpfEnabled bool // Enable connection tracking with eBPF
+	useEbpfConn bool // Enable connection tracking with eBPF
 	procRoot    string
 
 	dockerEnabled  bool
@@ -206,7 +206,7 @@ func main() {
 	flag.BoolVar(&flags.probe.spyProcs, "probe.proc.spy", true, "associate endpoints with processes (needs root)")
 	flag.StringVar(&flags.probe.procRoot, "probe.proc.root", "/proc", "location of the proc filesystem")
 	flag.BoolVar(&flags.probe.procEnabled, "probe.processes", true, "produce process topology & include procspied connections")
-	flag.BoolVar(&flags.probe.ebpfEnabled, "probe.ebpf", true, "enable connection tracking with eBPF")
+	flag.BoolVar(&flags.probe.useEbpfConn, "probe.ebpf.connections", true, "enable connection tracking with eBPF")
 
 	// Docker
 	flag.BoolVar(&flags.probe.dockerEnabled, "probe.docker", false, "collect Docker-related attributes for processes")

--- a/prog/main.go
+++ b/prog/main.go
@@ -91,6 +91,7 @@ type probeFlags struct {
 
 	spyProcs    bool // Associate endpoints with processes (must be root)
 	procEnabled bool // Produce process topology & process nodes in endpoint
+	ebpfEnabled bool // Enable connection tracking with eBPF
 	procRoot    string
 
 	dockerEnabled  bool
@@ -205,6 +206,7 @@ func main() {
 	flag.BoolVar(&flags.probe.spyProcs, "probe.proc.spy", true, "associate endpoints with processes (needs root)")
 	flag.StringVar(&flags.probe.procRoot, "probe.proc.root", "/proc", "location of the proc filesystem")
 	flag.BoolVar(&flags.probe.procEnabled, "probe.processes", true, "produce process topology & include procspied connections")
+	flag.BoolVar(&flags.probe.ebpfEnabled, "probe.ebpf", true, "enable connection tracking with eBPF")
 
 	// Docker
 	flag.BoolVar(&flags.probe.dockerEnabled, "probe.docker", false, "collect Docker-related attributes for processes")

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -140,8 +140,14 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 	var scanner procspy.ConnectionScanner
 	if flags.procEnabled {
 		processCache = process.NewCachingWalker(process.NewWalker(flags.procRoot))
-		scanner = procspy.NewConnectionScanner(processCache)
+		processCache.Tick()
 		p.AddTicker(processCache)
+		// if eBPF tracking is enabled, scan /proc synchronously, and just once
+		if flags.ebpfEnabled {
+			scanner = procspy.NewSyncConnectionScanner(processCache)
+		} else {
+			scanner = procspy.NewConnectionScanner(processCache)
+		}
 		p.AddReporter(process.NewReporter(processCache, hostID, process.GetDeltaTotalJiffies))
 	}
 
@@ -158,6 +164,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		SpyProcs:     flags.spyProcs,
 		UseConntrack: flags.useConntrack,
 		WalkProc:     flags.procEnabled,
+		EbpfEnabled:  flags.ebpfEnabled,
 		ProcRoot:     flags.procRoot,
 		BufferSize:   flags.conntrackBufferSize,
 		Scanner:      scanner,

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -164,7 +164,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		SpyProcs:     flags.spyProcs,
 		UseConntrack: flags.useConntrack,
 		WalkProc:     flags.procEnabled,
-		useEbpfConn:  flags.useEbpfConn,
+		UseEbpfConn:  flags.useEbpfConn,
 		ProcRoot:     flags.procRoot,
 		BufferSize:   flags.conntrackBufferSize,
 		Scanner:      scanner,

--- a/prog/probe.go
+++ b/prog/probe.go
@@ -143,7 +143,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		processCache.Tick()
 		p.AddTicker(processCache)
 		// if eBPF tracking is enabled, scan /proc synchronously, and just once
-		if flags.ebpfEnabled {
+		if flags.useEbpfConn {
 			scanner = procspy.NewSyncConnectionScanner(processCache)
 		} else {
 			scanner = procspy.NewConnectionScanner(processCache)
@@ -164,7 +164,7 @@ func probeMain(flags probeFlags, targets []appclient.Target) {
 		SpyProcs:     flags.spyProcs,
 		UseConntrack: flags.useConntrack,
 		WalkProc:     flags.procEnabled,
-		EbpfEnabled:  flags.ebpfEnabled,
+		useEbpfConn:  flags.useEbpfConn,
 		ProcRoot:     flags.procRoot,
 		BufferSize:   flags.conntrackBufferSize,
 		Scanner:      scanner,

--- a/scope
+++ b/scope
@@ -142,6 +142,9 @@ launch_command() {
     echo docker run --privileged -d --name=$SCOPE_CONTAINER_NAME --net=host --pid=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /var/run/scope/plugins:/var/run/scope/plugins \
+            -v /usr/src:/usr/src \
+            -v /lib/modules:/lib/modules \
+            -v /sys/kernel/debug:/sys/kernel/debug \
             -e CHECKPOINT_DISABLE \
             $WEAVESCOPE_DOCKER_ARGS $SCOPE_IMAGE --probe.docker=true "$@"
 }


### PR DESCRIPTION
Introduces connection tracking via eBPF. This allows scope to get notified of every connection event, without relying on the parsing of `/proc/net`, and therefore:
- improve performance
- increase reliability
### How it works

...
### Limitations:
- [ ] Does not support IPv6
- [ ] Sets `procspied: true` on connections coming from eBPF
- [ ] Reads 5000 bytes of `/proc/net/tcp`, whereas the actual file could be larger
